### PR TITLE
Add i64ToString option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,3 +58,18 @@ ChangeLog jsHS2
 * Fix testcase. Now test sync and async api
 * deps: chai@^3.4.1
 * deps: debug@^2.2.0
+
+# 0.2.12
+* Fix bug from CallbackTest and PromiseTest. If resultset hasn't rows after cause error. Because test always try getSchema and fetch.
+* Fix bug from CCursor. If error caused from close, return reject. But reject not defined function, fix it.
+* add Configuration option i64ToString. int64 convert i64val to float64. Int64 cannot convert float64, return Infinity. i64ToString is to true, convert string value of real value. 
+    * If you not set i64ToString that is to set true. You don't wanna this feature that flag set false.
+    * update cluster.json
+    * update testcase
+
+```
+# example
+
+i64ToString true, 7614985126350998549 -> '7614985126350998549' 
+i64ToString false, 7614985126350998549 -> Infinity
+```

--- a/cluster.json.sample
+++ b/cluster.json.sample
@@ -11,7 +11,8 @@
     "cdhVer": "5.3.0", // cdh version
     "thriftVer": "0.9.2", // thrift version
     "maxRows": 5120, // max row
-    "nullStr": "NULL" // NULL field replace to this string
+    "nullStr": "NULL", // NULL field replace to this string
+    "i64ToString": true // If you use i64 value that set true
   },
   "ApacheHive": {
     "auth": "NOSASL",
@@ -23,7 +24,8 @@
     "hiveVer": "1.1.0",
     "thriftVer": "0.9.2",
     "maxRows": 5120,
-    "nullStr": "NULL"
+    "nullStr": "NULL",
+    "i64ToString": true
   },
   "Query": {
     "query": "select * from default.something where part_date > '20141111'" // Enter your query

--- a/lib/CCursor.js
+++ b/lib/CCursor.js
@@ -391,7 +391,7 @@
     debug('CloseOperation -> function start');
 
     if (!that.operationHandle) {
-      return reject(new OperationError('Invalid operationHandle in CloseOperation'));
+      return callback(new OperationError('Invalid operationHandle in CloseOperation'));
     }
 
     var serviceType = that.getConfigure().getServiceType();

--- a/lib/Common/HS2Util.js
+++ b/lib/Common/HS2Util.js
@@ -5,6 +5,7 @@
   var IdlContainer = require('./IdlContainer');
   var util = require('util');
   var Int64 = require('node-int64');
+  var Big = require('big.js');
 
   function HS2Util () {}
 
@@ -29,10 +30,54 @@
     }, ms);
   };
 
-  HS2Util.prototype.modifyVal = function modifyVal (storedType, value) {
+  HS2Util.prototype.negate = function negate (value) {
+    value = (value ^ 0xff) + 1;
+    value = value & 0xff;
+
+    return value;
+  };
+
+  HS2Util.prototype.getInt64 = function getInt64 (buffer, offset) {
+    // This code from Int64 toNumber function. Using Big.js, convert to string.
+    var b = buffer, o = offset;
+
+    // Running sum of octets, doing a 2's complement
+    var value = new Big(0);
+    var m = new Big(1);
+    var negate = b[o] & 0x80, carry = 1;
+
+    for (var i = 7; i >= 0; i--) {
+      var v = b[o+i];
+
+      // 2's complement for negative numbers
+      if (negate) {
+        v = (v ^ 0xff) + carry;
+        carry = v >> 8;
+        v = v & 0xff;
+      }
+
+      value = value.plus((new Big(v)).times(m));
+      m = m.times(256);
+    }
+
+    if (negate) {
+      value = value.times(-1);
+    }
+
+    return value;
+  };
+
+  HS2Util.prototype.modifyVal = function modifyVal (storedType, value, i64ToString) {
+    var that = this;
+
     if (storedType === 'i64Val') {
       if (value && value.buffer) {
-        return (new Int64(value.buffer)).toString();
+        if (i64ToString) {
+          var int64Val = that.getInt64(value.buffer, value.offset);
+          return int64Val.toString();
+        } else {
+          return (new Int64(value.buffer, value.offset)).toString();
+        }
       } else if (value === null || value === undefined) {
         return null;
       } else {
@@ -84,7 +129,7 @@
         if (that.getIsNull(columns[colIdx][colType].nulls, rowIdx)) {
           row.push(configure.getNullStr());
         } else {
-          row.push(that.modifyVal(colType, columns[colIdx][colType].values[rowIdx]));
+          row.push(that.modifyVal(colType, columns[colIdx][colType].values[rowIdx], configure.getI64ToString()));
         }
       }
 

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -16,9 +16,13 @@
       throw new ConfigureError('Invalid Hostname');
     }
 
+    // --------------------------------------------------------------------------------
+    // Configuration of Connection
+    // --------------------------------------------------------------------------------
+
     // Connection
     options.host = _options.host;
-    options.auth = _options.auth || 'nosasl';
+    options.auth = (!!_options.auth) ? _options.auth.toLowerCase() : 'nosasl';
     options.port = _options.port || 10000;
     options.timeout = _options.timeout || 5;
     options.username = _options.username;
@@ -29,13 +33,6 @@
     options.hiveVer = _options.hiveVer || '0.13.1';
     options.thriftVer = _options.thriftVer || '0.9.2';
     options.cdhVer = _options.cdhVer || null;
-
-    // Cursor
-    options.maxRows = _options.maxRows || 5120;
-    options.nullStr = _options.nullStr || 'NULL';
-
-    options.auth = options.auth.toLowerCase();
-
     options.idlContainer = null;
 
     debug('port, :', options.port);
@@ -45,113 +42,43 @@
     debug('thirftVer, :', options.thriftVer);
     debug('cdhVer, :', options.cdhVer);
 
-    // Auth
-    function getAuth () {
-      return options.auth;
-    }
+    that.getAuth      = function getAuth () { return options.auth; };
+    that.setAuth      = function setAuth (auth) { options.auth = auth; };
+    that.getHost      = function getHost () { return options.host; };
+    that.setHost      = function setHost (host) { options.host = host; };
+    that.getPort      = function getPort () { return options.port; };
+    that.setPort      = function setPort (port) { options.port = port; };
+    that.getTimeout   = function getTimeout () { return options.timeout; };
+    that.setTimeout   = function setTimeout (timeout) { options.timeout = timeout; };
+    that.getUsername  = function getUsername () { return options.username; };
+    that.setUsername  = function setUsername (username) { options.username = username; };
+    that.getPassword  = function getPassword () { return options.password; };
+    that.setPassword  = function setPassword (password) { options.password = password; };
+    that.getHiveType  = function getHiveType () { return options.hiveType; };
+    that.setHiveType  = function setHiveType (hiveType) { options.hiveType = hiveType; };
+    that.getHiveVer   = function getHiveVer () { return options.hiveVer; };
+    that.setHiveVer   = function setHiveVer (hiveType) { options.hiveVer = hiveVer; };
+    that.getThriftVer = function getThriftVer () { return options.thriftVer; };
+    that.setThriftVer = function setThriftVer (thriftVer) { options.thriftVer = thriftVer; };
+    that.getCDHVer    = function getCDHVer () { return options.cdhVer; };
+    that.setCDHVer    = function setCDHVer (cdhVer) { options.cdhVer = cdhVer; };
 
-    function setAuth (auth) {
-      options.auth = auth;
-    }
-
-    // Host
-    function getHost () {
-      return options.host;
-    }
-
-    function setHost (host) {
-      options.host = host;
-    }
-
-    // Port
-    function getPort () {
-      return options.port;
-    }
-
-    function setPort (port) {
-      options.port = port;
-    }
-
-    // Timeout
-    function getTimeout () {
-      return options.timeout;
-    }
-
-    function setTimeout (timeout) {
-      options.timeout = timeout;
-    }
-
-    // Username
-    function getUsername () {
-      return options.username;
-    }
-
-    function setUsername (username) {
-      options.username = username;
-    }
-
-    // Password
-    function getPassword () {
-      return options.password;
-    }
-
-    function setPassword (password) {
-      options.password = password;
-    }
-
-    // HiveType
-    function getHiveType () {
-      return options.hiveType;
-    }
-
-    function setHiveType (hiveType) {
-      options.hiveType = hiveType;
-    }
-
-    function getHiveVer () {
-      return options.hiveVer;
-    }
-
-    function setHiveVer (hiveType) {
-      options.hiveVer = hiveVer;
-    }
-
-    function getThriftVer () {
-      return options.thriftVer;
-    }
-
-    function setThriftVer (thriftVer) {
-      options.thriftVer = thriftVer;
-    }
-
-    function getCDHVer () {
-      return options.cdhVer;
-    }
-
-    function setCDHVer (cdhVer) {
-      options.cdhVer = cdhVer;
-    }
-
+    // --------------------------------------------------------------------------------
+    // Configuration of Cursor
+    // --------------------------------------------------------------------------------
+    // Cursor
     options.maxRows = _options.maxRows || 5120;
     options.nullStr = _options.nullStr || 'NULL';
+    options.i64ToString = _options.i64ToString || true;
 
-    function getMaxRows () {
-      return options.maxRows;
-    }
+    that.getMaxRows     = function getMaxRows () { return options.maxRows; };
+    that.setMaxRows     = function setMaxRows (maxRows) { options.maxRows = maxRows; };
+    that.getNullStr     = function getNullStr () { return options.nullStr; };
+    that.setNullStr     = function setNullStr (nullStr) { options.nullStr = nullStr; };
+    that.getI64ToString = function getI64ToString () { return options.i64ToString; };
+    that.setI64ToString = function setI64ToString (i64ToString) { options.i64ToString = i64ToString; };
 
-    function setMaxRows (maxRows) {
-      options.maxRows = maxRows;
-    }
-
-    function getNullStr () {
-      return options.nullStr;
-    }
-
-    function setNullStr (nullStr) {
-      options.nullStr = nullStr;
-    }
-
-    function initialize () {
+    that.initialize = function initialize () {
       options.idlContainer = new IdlContainer();
 
       return new Promise(function (resolve, reject) {
@@ -163,9 +90,9 @@
           }
         });
       });
-    }
+    };
 
-    function cb$initialize (cb) {
+    that.cb$initialize = function cb$initialize (cb) {
       options.idlContainer = new IdlContainer();
       options.idlContainer.cb$initialize(that, function (err) {
         if (err) {
@@ -174,56 +101,15 @@
           cb(null);
         }
       });
-    }
+    };
 
-    function getService () {
-      return options.idlContainer.getService();
-    }
+    that.getService     = function getService () { return options.idlContainer.getService(); };
+    that.getServiceType = function getServiceType () { return options.idlContainer.getServiceType(); };
+    that.getIsInit      = function getIsInit () { return !!options.idlContainer; };
 
-    function getServiceType () {
-      return options.idlContainer.getServiceType();
-    }
-
-    function getIsInit () {
-      return !!options.idlContainer;
-    }
-
-    function getOperationStatuses () {
+    that.getOperationStatuses = function getOperationStatuses () {
       return options.idlContainer.getServiceType().TOperationState;
-    }
-
-    that.getAuth = getAuth;
-    that.setAuth = setAuth;
-    that.getHost = getHost;
-    that.setHost = setHost;
-    that.getPort = getPort;
-    that.setPort = setPort;
-    that.getTimeout = getTimeout;
-    that.setTimeout = setTimeout;
-    that.getUsername = getUsername;
-    that.setUsername = setUsername;
-    that.getPassword = getPassword;
-    that.setPassword = setPassword;
-    that.getHiveType = getHiveType;
-    that.setHiveType = setHiveType;
-    that.getHiveVer = getHiveVer;
-    that.setHiveVer = setHiveVer;
-    that.getThriftVer = getThriftVer;
-    that.setThriftVer = setThriftVer;
-    that.getCDHVer = getCDHVer;
-    that.setCDHVer = setCDHVer;
-    that.getMaxRows = getMaxRows;
-    that.setMaxRows = setMaxRows;
-    that.getNullStr = getNullStr;
-    that.setNullStr = setNullStr;
-
-    that.initialize = initialize;
-    that.cb$initialize = cb$initialize;
-    that.getService = getService;
-    that.getServiceType = getServiceType;
-    that.getOperationStatuses = getOperationStatuses;
-
-    that.getIsInit = getIsInit;
+    };
   }
 
   module.exports = Configuration;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshs2",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Hive Server2 Driver for Javascript",
   "keywords": [
     "Hive",
@@ -24,6 +24,7 @@
     "node": ">=0.10.23"
   },
   "dependencies": {
+    "big.js": "^3.1.3",
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "node-int64": "^0.3.3",

--- a/test/CallbackTest.js
+++ b/test/CallbackTest.js
@@ -151,6 +151,7 @@ describe('ThriftDriverTest', function () {
 
         testConf.jshs2.maxRows = testConf.config[testConf.config.use].maxRows;
         testConf.jshs2.nullStr = testConf.config[testConf.config.use].nullStr;
+        testConf.jshs2.i64ToString = testConf.config[testConf.config.use].i64ToString;
 
         callback(null);
       },
@@ -232,43 +233,51 @@ describe('ThriftDriverTest', function () {
           if (err) {
             callback(err);
           } else {
-            callback(null);
+            callback(null, result);
           }
         });
       },
-      function waitAndLogStep (callback) {
+      function waitAndLogStep (execResult, callback) {
         waitAndLog(cursor, function (err) {
           if (err) {
             callback(err);
           } else {
-            callback(null);
+            callback(null, execResult);
           }
         });
       },
-      function schemaStep (callback) {
-        cursor.getSchema(function (err, schema) {
-          if (err) {
-            callback(err);
-          } else {
-            debug('schema -> ', schema);
+      function schemaStep (execResult, callback) {
+        if (execResult.hasResultSet) {
+          cursor.getSchema(function (err, schema) {
+            if (err) {
+              callback(err);
+            } else {
+              debug('schema -> ', schema);
 
-            callback(null);
-          }
-        });
+              callback(null, execResult);
+            }
+          });
+        } else {
+          callback(null, execResult);
+        }
       },
-      function fetchBlockStep (callback) {
-        cursor.fetchBlock(function (err, result) {
-          if (err) {
-            callback(err);
-          } else {
-            debug('rows ->', result.rows.length);
-            debug('rows ->', result.hasMoreRows);
+      function fetchBlockStep (execResult, callback) {
+        if (execResult.hasResultSet) {
+          cursor.fetchBlock(function (err, result) {
+            if (err) {
+              callback(err);
+            } else {
+              debug('rows ->', result.rows.length);
+              debug('rows ->', result.hasMoreRows);
 
-            callback(null, result.rows);
-          }
-        });
+              callback(null, execResult, result.rows);
+            }
+          });
+        } else {
+          callback(null, execResult);
+        }
       }
-    ], function (err, rows) {
+    ], function (err, execResult, rows) {
       if (err) {
         debug('Error caused, ');
         debug('message:  ' + err.message);
@@ -279,7 +288,7 @@ describe('ThriftDriverTest', function () {
         });
       } else {
         setImmediate(function () {
-          should.not.equal(rows.length > 1);
+          should.not.equal(!execResult.hasResultSet || rows.length > 1);
 
           done();
         });
@@ -296,34 +305,42 @@ describe('ThriftDriverTest', function () {
           if (err) {
             callback(err);
           } else {
-            callback(null);
+            callback(null, result);
           }
         });
       },
-      function schemaStep (callback) {
-        cursor.getSchema(function (err, schema) {
-          if (err) {
-            callback(err);
-          } else {
-            debug('schema -> ', schema);
+      function schemaStep (execResult, callback) {
+        if (execResult.hasResultSet) {
+          cursor.getSchema(function (err, schema) {
+            if (err) {
+              callback(err);
+            } else {
+              debug('schema -> ', schema);
 
-            callback(null);
-          }
-        });
+              callback(null, execResult);
+            }
+          });
+        } else {
+          callback(null, execResult);
+        }
       },
-      function fetchBlockStep (callback) {
-        cursor.fetchBlock(function (err, result) {
-          if (err) {
-            callback(err);
-          } else {
-            debug('rows ->', result.rows.length);
-            debug('rows ->', result.hasMoreRows);
+      function fetchBlockStep (execResult, callback) {
+        if (execResult.hasResultSet) {
+          cursor.fetchBlock(function (err, result) {
+            if (err) {
+              callback(err);
+            } else {
+              debug('rows ->', result.rows.length);
+              debug('rows ->', result.hasMoreRows);
 
-            callback(null, result.rows);
-          }
-        });
+              callback(null, execResult, result.rows);
+            }
+          });
+        } else {
+          callback(null, execResult);
+        }
       }
-    ], function (err, rows) {
+    ], function (err, execResult, rows) {
       if (err) {
         debug('Error caused, ');
         debug('message:  ' + err.message);
@@ -334,7 +351,7 @@ describe('ThriftDriverTest', function () {
         });
       } else {
         setImmediate(function () {
-          should.not.equal(rows.length > 1);
+          should.not.equal(!execResult.hasResultSet || rows.length > 1);
 
           done();
         });


### PR DESCRIPTION
# Fix bug
	* Fix bug from CallbackTest and PromiseTest. If resultset hasn't rows after cause error. Because test always try getSchema and fetch.
	* Fix bug from CCursor. If error caused from close, return reject. But reject not defined function, fix it.

# New feature
	* add Configuration option i64ToString. int64 convert i64val to float64. Int64 cannot convert float64, return Infinity. i64ToString is to true, convert string value of real value.
	* If you not set i64ToString that is to set true. You don't wanna this feature that flag set false.
	* update cluster.json
	* update testcase

```
# example

i64ToString true, 7614985126350998549 -> '7614985126350998549'
i64ToString false, 7614985126350998549 -> Infinity
```