### PR TITLE
fix: Drop usage of lodash, use simple helper for first, fix #22

### DIFF
--- a/lib/common/HS2Util.js
+++ b/lib/common/HS2Util.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const Int64 = require('node-int64');
 const Big = require('big.js');
 
@@ -16,6 +15,12 @@ const BITMASK = [1, 2, 4, 8, 16, 32, 64, 128];
 
 let OPERATION_STATES = null;
 let TTYPE_ID = null;
+
+function first(array) {
+  return (array != null && array.length)
+    ? array[0]
+    : undefined
+}
 
 class HS2Util {
   static sleep(ms) {
@@ -87,7 +92,7 @@ class HS2Util {
 
   static makeJson(storedTypes, columns, schema) {
     const rows = [];
-    const ilen = _(columns).first()[_(storedTypes).first()].values.length;
+    const ilen = first(columns)[first(storedTypes)].values.length;
     const jlen = columns.length;
 
     for (let i = 0; i < ilen; i += 1) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "big.js": "^3.1.3",
     "debug": "^2.2.0",
-    "lodash": "^3.10.1",
     "moment": "^2.17.1",
     "node-int64": "^0.3.3",
     "thrift": "^0.9.3"


### PR DESCRIPTION
Hello!

refs https://github.com/cube-js/cube.js/issues/2799
refs https://github.com/imjuni/jshs2/issues/22

- I copy/paste first method from lodash, because it's one-liner
- I drop usage of lodash (It was used only for first method)

Thanks